### PR TITLE
Allow for programming language used in editor to be synced for both matched users

### DIFF
--- a/frontend/src/components/AwaitChangeProgrammingLanguageAlert.js
+++ b/frontend/src/components/AwaitChangeProgrammingLanguageAlert.js
@@ -1,31 +1,30 @@
-import * as React from 'react';
-import Dialog from '@mui/material/Dialog';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
-import { useSelector } from 'react-redux';
-import { selectAwaitAlertOpen } from '../redux/EditorSlice';
+import * as React from 'react'
+import Dialog from '@mui/material/Dialog'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+import { useSelector } from 'react-redux'
+import { selectAwaitAlertOpen } from '../redux/EditorSlice'
 
-export default function AwaitChangeProgrammingLanguageDialog({matchedUserId}) {
-
+export default function AwaitChangeProgrammingLanguageDialog ({ matchedUserId }) {
   const awaitAlertOpen = useSelector(selectAwaitAlertOpen)
 
   return (
     <div>
       <Dialog
         open={awaitAlertOpen}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
+        aria-labelledby='alert-dialog-title'
+        aria-describedby='alert-dialog-description'
       >
-        <DialogTitle id="alert-dialog-title">
-          {"Awaiting Matched User to agree to change"}
+        <DialogTitle id='alert-dialog-title'>
+          Awaiting Matched User to agree to change
         </DialogTitle>
         <DialogContent>
-          <DialogContentText id="alert-dialog-description">
+          <DialogContentText id='alert-dialog-description'>
             Awaiting for {matchedUserId} to agree to change the programming language.
           </DialogContentText>
         </DialogContent>
       </Dialog>
     </div>
-  );
+  )
 }

--- a/frontend/src/components/AwaitChangeProgrammingLanguageAlert.js
+++ b/frontend/src/components/AwaitChangeProgrammingLanguageAlert.js
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import { useSelector } from 'react-redux';
+import { selectAwaitAlertOpen } from '../redux/EditorSlice';
+
+export default function AwaitChangeProgrammingLanguageDialog({matchedUserId}) {
+
+  const awaitAlertOpen = useSelector(selectAwaitAlertOpen)
+
+  return (
+    <div>
+      <Dialog
+        open={awaitAlertOpen}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {"Awaiting Matched User to agree to change"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            Awaiting for {matchedUserId} to agree to change the programming language.
+          </DialogContentText>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/components/ChangeProgrammingLanguageAlert.js
+++ b/frontend/src/components/ChangeProgrammingLanguageAlert.js
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectChangeProgrammingLanguageAlert, setChangeProgrammingLanguageAlert } from '../redux/EditorSlice';
+
+export default function ProgrammingLanguageDialog({matchedUserId, language, denyChange, agreeChange}) {
+  
+  const open = useSelector(selectChangeProgrammingLanguageAlert)
+  const dispatch = useDispatch()
+
+  const handleDisagree = () => {
+    denyChange()
+    dispatch(setChangeProgrammingLanguageAlert(false))
+  }
+
+  const handleAgree = () => {
+    agreeChange()
+    dispatch(setChangeProgrammingLanguageAlert(false))
+  }
+
+  return (
+    <div>
+      <Dialog
+        open={open}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {"Change Programming Language?"}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {matchedUserId} is trying to change the programming language to {language}.
+            Do you agree to the change?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDisagree}>Disagree</Button>
+          <Button onClick={handleAgree} autoFocus>
+            Agree
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/src/components/ChangeProgrammingLanguageAlert.js
+++ b/frontend/src/components/ChangeProgrammingLanguageAlert.js
@@ -9,7 +9,6 @@ import { useDispatch, useSelector } from 'react-redux'
 import { selectChangeProgrammingLanguageAlert, setChangeProgrammingLanguageAlert } from '../redux/EditorSlice'
 
 export default function ProgrammingLanguageDialog ({ matchedUserId, language, denyChange, agreeChange }) {
-  
   const open = useSelector(selectChangeProgrammingLanguageAlert)
   const dispatch = useDispatch()
 

--- a/frontend/src/components/ChangeProgrammingLanguageAlert.js
+++ b/frontend/src/components/ChangeProgrammingLanguageAlert.js
@@ -1,14 +1,14 @@
-import * as React from 'react';
-import Button from '@mui/material/Button';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import DialogTitle from '@mui/material/DialogTitle';
-import { useDispatch, useSelector } from 'react-redux';
-import { selectChangeProgrammingLanguageAlert, setChangeProgrammingLanguageAlert } from '../redux/EditorSlice';
+import * as React from 'react'
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogActions from '@mui/material/DialogActions'
+import DialogContent from '@mui/material/DialogContent'
+import DialogContentText from '@mui/material/DialogContentText'
+import DialogTitle from '@mui/material/DialogTitle'
+import { useDispatch, useSelector } from 'react-redux'
+import { selectChangeProgrammingLanguageAlert, setChangeProgrammingLanguageAlert } from '../redux/EditorSlice'
 
-export default function ProgrammingLanguageDialog({matchedUserId, language, denyChange, agreeChange}) {
+export default function ProgrammingLanguageDialog ({ matchedUserId, language, denyChange, agreeChange }) {
   
   const open = useSelector(selectChangeProgrammingLanguageAlert)
   const dispatch = useDispatch()
@@ -27,14 +27,14 @@ export default function ProgrammingLanguageDialog({matchedUserId, language, deny
     <div>
       <Dialog
         open={open}
-        aria-labelledby="alert-dialog-title"
-        aria-describedby="alert-dialog-description"
+        aria-labelledby='alert-dialog-title'
+        aria-describedby='alert-dialog-description'
       >
-        <DialogTitle id="alert-dialog-title">
-          {"Change Programming Language?"}
+        <DialogTitle id='alert-dialog-title'>
+          Change Programming Language?
         </DialogTitle>
         <DialogContent>
-          <DialogContentText id="alert-dialog-description">
+          <DialogContentText id='alert-dialog-description'>
             {matchedUserId} is trying to change the programming language to {language}.
             Do you agree to the change?
           </DialogContentText>
@@ -47,5 +47,5 @@ export default function ProgrammingLanguageDialog({matchedUserId, language, deny
         </DialogActions>
       </Dialog>
     </div>
-  );
+  )
 }

--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -20,15 +20,15 @@ function determineLanguage (selectedLanguage) {
   }
 }
 
-function startingCode (language) {
-  if (language === 'Python') {
-    return '## Write down your solutions here\n'
-  } else if (language === 'Java') {
-    return '/* Write down your solutions here */\n'
-  } else if (language === 'C++') {
-    return '/* Write down your solutions here */\n'
-  }
-}
+// function startingCode (language) {
+//   if (language === 'Python') {
+//     return '## Write down your solutions here\n'
+//   } else if (language === 'Java') {
+//     return '/* Write down your solutions here */\n'
+//   } else if (language === 'C++') {
+//     return '/* Write down your solutions here */\n'
+//   }
+// }
 
 export const Editor = ({ socketRef }) => {
   const dispatch = useDispatch()
@@ -64,7 +64,7 @@ export const Editor = ({ socketRef }) => {
         justifyContent: 'center'
       }}
     >
-      <AwaitChangeProgrammingLanguageDialog matchedUserId={matchedUserid}/>
+      <AwaitChangeProgrammingLanguageDialog matchedUserId={matchedUserid} />
       <Card
         style={{
           width: '100%',

--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -6,7 +6,9 @@ import { materialLightInit } from '@uiw/codemirror-theme-material'
 import { python } from '@codemirror/lang-python'
 import { java } from '@codemirror/lang-java'
 import { cpp } from '@codemirror/lang-cpp'
-import { selectCode, setCode } from '../redux/EditorSlice'
+import { selectCode, setCode, selectCodeEditorLanguage, setAwaitAlertOpen } from '../redux/EditorSlice'
+import { selectMatchedUserid } from '../redux/MatchingSlice'
+import AwaitChangeProgrammingLanguageDialog from '../components/AwaitChangeProgrammingLanguageAlert'
 
 function determineLanguage (selectedLanguage) {
   if (selectedLanguage === 'Python') {
@@ -32,12 +34,16 @@ export const Editor = ({ socketRef }) => {
   const dispatch = useDispatch()
   const reduxCode = useSelector(selectCode)
   const [languages] = useState(['Python', 'Java', 'C++'])
-  const [selectedLanguage, setSelectedLanguage] = useState('')
+  const matchedUserid = useSelector(selectMatchedUserid)
+  const selectedLanguage = useSelector(selectCodeEditorLanguage)
 
   const handleLanguageChange = (e) => {
     const selectedValue = e.target.value
-    setCode(startingCode(selectedValue))
-    setSelectedLanguage(selectedValue) // Update the selected language state
+    dispatch(setAwaitAlertOpen(true))
+    socketRef.current.emit('ChangeEditorLanguage', { language: selectedValue }, (error) => {
+      console.log(error)
+    })
+    // setSelectedLanguage(selectedValue) // Update the selected language state
   }
 
   const handleCodeChange = (value, data) => {
@@ -58,6 +64,7 @@ export const Editor = ({ socketRef }) => {
         justifyContent: 'center'
       }}
     >
+      <AwaitChangeProgrammingLanguageDialog matchedUserId={matchedUserid}/>
       <Card
         style={{
           width: '100%',

--- a/frontend/src/components/MatchingComponent.js
+++ b/frontend/src/components/MatchingComponent.js
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import io from 'socket.io-client'
-import { setRoomId, setQuestionData, selectAwaitingMatching, setAwaitingMatching, setMatchedUserId, selectDifficulty, setDifficulty } from '../redux/MatchingSlice'
+import { setRoomId, setQuestionData, selectAwaitingMatching, setAwaitingMatching, setMatchedUserId, selectDifficulty, setDifficulty, setMatchingLanguages } from '../redux/MatchingSlice'
 import { setShowError, setErrorMessage } from '../redux/ErrorSlice'
 import Grid from '@mui/material/Grid'
 import { Box } from '@mui/material'
@@ -14,6 +14,7 @@ import Select from '@mui/material/Select'
 import Typography from '@mui/material/Typography'
 import CircularProgress from '@mui/material/CircularProgress'
 import { selectPreferredLanguages, selectUserid } from '../redux/UserSlice'
+import { setCode } from '../redux/EditorSlice'
 import Card from '@mui/material/Card'
 
 const MATCHINGSERVER = 'http://localhost:4000'
@@ -68,10 +69,13 @@ function MatchingComponent () {
       }
     })
     dispatch(setAwaitingMatching(true))
-    socket.current.on('MatchingSuccess', ({ matchedUserId, roomId, questionData }) => {
+    socket.current.on('MatchingSuccess', ({ matchedUserId, roomId, questionData, matchingLanguages }) => {
       dispatch(setMatchedUserId(matchedUserId))
       dispatch(setRoomId(roomId))
       dispatch(setQuestionData(questionData))
+      console.log(matchingLanguages)
+      dispatch(setMatchingLanguages(matchingLanguages))
+      dispatch(setCode('Please choose a language to begin!\n'))
       navigate('/collab')
     })
     socket.current.on('ErrorMatching', ({ errorMessage }) => {

--- a/frontend/src/pages/CollabPage.js
+++ b/frontend/src/pages/CollabPage.js
@@ -13,8 +13,10 @@ import Container from '@mui/material/Container'
 import TextField from '@mui/material/TextField'
 import { Typography } from '@mui/material'
 import { selectUserid } from '../redux/UserSlice'
-import { selectRoomid, selectMatchedUserid, selectQuestionData } from '../redux/MatchingSlice'
+import { selectRoomid, selectMatchedUserid, selectQuestionData, selectMatchingLanguages } from '../redux/MatchingSlice'
 import { setErrorMessage, setShowError } from '../redux/ErrorSlice'
+import { setAwaitAlertOpen, selectNewProgrammingLanguage, setCode, setCodeEditorLanguage, setNewProgrammingLanguage, setChangeProgrammingLanguageAlert } from '../redux/EditorSlice'
+import ProgrammingLanguageDialog from '../components/ChangeProgrammingLanguageAlert'
 
 const SOCKETSERVER = 'http://localhost:2000'
 
@@ -28,10 +30,12 @@ const connectionOptions = {
 function CollabPage () {
   const [message, setMessage] = useState('')
   const [messages, setMessages] = useState([])
+  const newProgrammingLanguage = useSelector(selectNewProgrammingLanguage)
   const userid = useSelector(selectUserid)
   const matchedUserid = useSelector(selectMatchedUserid)
   const matchedUseridRef = useRef(matchedUserid)
   const roomid = useSelector(selectRoomid)
+  const matchingLanguages = useSelector(selectMatchingLanguages)
   const questionData = useSelector(selectQuestionData)
   const dispatch = useDispatch()
   const socket = useRef()
@@ -69,6 +73,30 @@ function CollabPage () {
       setMessages(messages => [...messages, messageString])
     })
 
+    socket.current.on('CodeChange', (code) => {
+      console.log(code.code)
+      dispatch(setCode(code.code))
+    })
+
+    socket.current.on('CheckChangeEditorLanguage', ({language}) => {
+      dispatch(setNewProgrammingLanguage(language))
+      dispatch(setChangeProgrammingLanguageAlert(true))
+    })
+
+    socket.current.on('ConfirmChangeEditorLanguage', ({ agree, language }) => {
+      console.log("matched user has responded:")
+      console.log(agree)
+      console.log(language)
+      if (agree) {
+        dispatch(setCodeEditorLanguage(language))
+        dispatch(setAwaitAlertOpen(false))
+      } else {
+        dispatch(setAwaitAlertOpen(false))
+        dispatch(setErrorMessage(`${matchedUserid} has declined to change the programming language`))
+        dispatch(setShowError(true))
+      }
+    })
+
     socket.current.on('DisconnectPeer', (message) => {
       dispatch(setErrorMessage('Peer has disconnected'))
       dispatch(setShowError(true))
@@ -84,9 +112,38 @@ function CollabPage () {
     }
   }
 
+  const denyProgrammingLanguageChange = () => {
+    console.log('disagree change')
+    socket.current.emit('ConfirmChangeEditorLanguage', { agree:false, language:newProgrammingLanguage }, (error) => {
+      if (error) {
+        dispatch(setErrorMessage(error))
+        dispatch(setShowError(true))
+      }
+    })
+    dispatch(setNewProgrammingLanguage(''))
+  }
+
+  const agreeProgrammingLanguageChange = () => {
+    console.log('agree change')
+    socket.current.emit('ConfirmChangeEditorLanguage', { agree:true, language:newProgrammingLanguage }, (error) => {
+      if (error) {
+        dispatch(setErrorMessage(error))
+        dispatch(setShowError(true))
+      }
+    })
+    dispatch(setNewProgrammingLanguage(''))
+    dispatch(setCodeEditorLanguage(newProgrammingLanguage))
+  }
+
   return (
     <>
       <div style={{ width: '100%', height: '70%', paddingTop: '1rem' }}>
+        <ProgrammingLanguageDialog 
+          matchedUserId={matchedUserid}
+          language={newProgrammingLanguage}
+          denyChange={denyProgrammingLanguageChange}
+          agreeChange={agreeProgrammingLanguageChange}
+        />
         <Box
           display='flex'
           flexDirection='row'
@@ -97,11 +154,21 @@ function CollabPage () {
             <QuestionComponent questionData={questionData} />
           </div>
           <div style={{ width: '50%', height: '100%' }}>
-            <Editor />
+            <Editor socketRef={socket}/>
           </div>
         </Box>
       </div>
       <Container>
+        <Grid>
+          <Typography variant='h3' component='h2'>
+            Matching Programming Languages:
+          </Typography>
+          {matchingLanguages.length > 0 && matchingLanguages.map((language, i) => (
+            <div key={i}>
+              <Typography>{language}</Typography>
+            </div>
+          ))}
+        </Grid>
         <Grid>
           <Typography variant='h3' component='h2'>
             Matched with : {matchedUserid}

--- a/frontend/src/pages/CollabPage.js
+++ b/frontend/src/pages/CollabPage.js
@@ -78,13 +78,13 @@ function CollabPage () {
       dispatch(setCode(code.code))
     })
 
-    socket.current.on('CheckChangeEditorLanguage', ({language}) => {
+    socket.current.on('CheckChangeEditorLanguage', ({ language }) => {
       dispatch(setNewProgrammingLanguage(language))
       dispatch(setChangeProgrammingLanguageAlert(true))
     })
 
     socket.current.on('ConfirmChangeEditorLanguage', ({ agree, language }) => {
-      console.log("matched user has responded:")
+      console.log('matched user has responded:')
       console.log(agree)
       console.log(language)
       if (agree) {
@@ -114,7 +114,7 @@ function CollabPage () {
 
   const denyProgrammingLanguageChange = () => {
     console.log('disagree change')
-    socket.current.emit('ConfirmChangeEditorLanguage', { agree:false, language:newProgrammingLanguage }, (error) => {
+    socket.current.emit('ConfirmChangeEditorLanguage', { agree: false, language: newProgrammingLanguage }, (error) => {
       if (error) {
         dispatch(setErrorMessage(error))
         dispatch(setShowError(true))
@@ -125,7 +125,7 @@ function CollabPage () {
 
   const agreeProgrammingLanguageChange = () => {
     console.log('agree change')
-    socket.current.emit('ConfirmChangeEditorLanguage', { agree:true, language:newProgrammingLanguage }, (error) => {
+    socket.current.emit('ConfirmChangeEditorLanguage', { agree: true, language: newProgrammingLanguage }, (error) => {
       if (error) {
         dispatch(setErrorMessage(error))
         dispatch(setShowError(true))
@@ -138,7 +138,7 @@ function CollabPage () {
   return (
     <>
       <div style={{ width: '100%', height: '70%', paddingTop: '1rem' }}>
-        <ProgrammingLanguageDialog 
+        <ProgrammingLanguageDialog
           matchedUserId={matchedUserid}
           language={newProgrammingLanguage}
           denyChange={denyProgrammingLanguageChange}
@@ -154,7 +154,7 @@ function CollabPage () {
             <QuestionComponent questionData={questionData} />
           </div>
           <div style={{ width: '50%', height: '100%' }}>
-            <Editor socketRef={socket}/>
+            <Editor socketRef={socket} />
           </div>
         </Box>
       </div>

--- a/frontend/src/redux/EditorSlice.js
+++ b/frontend/src/redux/EditorSlice.js
@@ -3,18 +3,42 @@ import { createSlice } from '@reduxjs/toolkit'
 export const editorSlice = createSlice({
   name: 'editor',
   initialState: {
-    code: 'Please choose a language to begin!\n'
+    code: 'Please choose a language to begin!\n',
+    codeEditorLanguage: '',
+    newProgrammingLanguage: '',
+    awaitAlertOpen: false,
+    changeProgrammingLanguageAlert: false
   },
   reducers: {
     setCode: (state, action) => {
       state.code = action.payload
+    },
+    setCodeEditorLanguage: (state, action) => {
+      state.codeEditorLanguage = action.payload
+    },
+    setNewProgrammingLanguage: (state, action) => {
+      state.newProgrammingLanguage = action.payload
+    },
+    setAwaitAlertOpen: (state, action) => {
+      state.awaitAlertOpen = action.payload
+    },
+    setChangeProgrammingLanguageAlert: (state, action) => {
+      state.changeProgrammingLanguageAlert = action.payload
     }
   }
 })
 
 // Action creators are generated for each case reducer function
-export const { setCode } = editorSlice.actions
+export const { setCode, setCodeEditorLanguage, setAwaitAlertOpen, setChangeProgrammingLanguageAlert, setNewProgrammingLanguage } = editorSlice.actions
 
 export const selectCode = (state) => state.editor.code
+
+export const selectCodeEditorLanguage = (state) => state.editor.codeEditorLanguage
+
+export const selectNewProgrammingLanguage= (state) => state.editor.newProgrammingLanguage
+
+export const selectAwaitAlertOpen = (state) => state.editor.awaitAlertOpen
+
+export const selectChangeProgrammingLanguageAlert = (state) => state.editor.changeProgrammingLanguageAlert
 
 export default editorSlice.reducer

--- a/frontend/src/redux/EditorSlice.js
+++ b/frontend/src/redux/EditorSlice.js
@@ -35,7 +35,7 @@ export const selectCode = (state) => state.editor.code
 
 export const selectCodeEditorLanguage = (state) => state.editor.codeEditorLanguage
 
-export const selectNewProgrammingLanguage= (state) => state.editor.newProgrammingLanguage
+export const selectNewProgrammingLanguage = (state) => state.editor.newProgrammingLanguage
 
 export const selectAwaitAlertOpen = (state) => state.editor.awaitAlertOpen
 

--- a/frontend/src/redux/MatchingSlice.js
+++ b/frontend/src/redux/MatchingSlice.js
@@ -7,6 +7,7 @@ export const matchingSlice = createSlice({
     difficulty: '',
     roomid: '',
     matchedUserid: '',
+    matchingLanguages: [],
     questionData: {}
   },
   reducers: {
@@ -22,6 +23,9 @@ export const matchingSlice = createSlice({
     setDifficulty: (state, action) => {
       state.difficulty = action.payload
     },
+    setMatchingLanguages: (state, action) => {
+      state.matchingLanguages = action.payload
+    },
     setQuestionData: (state, action) => {
       state.questionData = action.payload
     }
@@ -29,7 +33,7 @@ export const matchingSlice = createSlice({
 })
 
 // Action creators are generated for each case reducer function
-export const { setRoomId, setMatchedUserId, setQuestionData, setAwaitingMatching, setDifficulty } = matchingSlice.actions
+export const { setRoomId, setMatchedUserId, setQuestionData, setAwaitingMatching, setDifficulty, setMatchingLanguages, setCodeEditorLanguage } = matchingSlice.actions
 
 export const selectRoomid = (state) => state.match.roomid
 
@@ -40,5 +44,7 @@ export const selectMatchedUserid = (state) => state.match.matchedUserid
 export const selectQuestionData = (state) => state.match.questionData
 
 export const selectAwaitingMatching = (state) => state.match.awaitingMatching
+
+export const selectMatchingLanguages = (state) => state.match.matchingLanguages
 
 export default matchingSlice.reducer

--- a/microservices/matchingService/app.js
+++ b/microservices/matchingService/app.js
@@ -50,7 +50,7 @@ io.on('connection', (socket) => {
           callback()
         }
         console.log(`${user2id} joining room with ${user1id}`)
-        if (user2id) {    
+        if (user2id) {
           try {
             const matchingLanguages = matchingService.findMatchingLanguages(languages, user.languages)
             const result = await axios.post(collabServiceUrl + 'createroom', { user1id, user2id })

--- a/microservices/matchingService/app.js
+++ b/microservices/matchingService/app.js
@@ -50,11 +50,12 @@ io.on('connection', (socket) => {
           callback()
         }
         console.log(`${user2id} joining room with ${user1id}`)
-        if (user2id) {
+        if (user2id) {    
           try {
+            const matchingLanguages = matchingService.findMatchingLanguages(languages, user.languages)
             const result = await axios.post(collabServiceUrl + 'createroom', { user1id, user2id })
-            io.to(socket.id).emit('MatchingSuccess', { matchedUserId: user1id, roomId: result.data.roomId, questionData: result.data.questionData })
-            io.to(user1socket).emit('MatchingSuccess', { matchedUserId: user2id, roomId: result.data.roomId, questionData: result.data.questionData })
+            io.to(socket.id).emit('MatchingSuccess', { matchedUserId: user1id, roomId: result.data.roomId, questionData: result.data.questionData, matchingLanguages })
+            io.to(user1socket).emit('MatchingSuccess', { matchedUserId: user2id, roomId: result.data.roomId, questionData: result.data.questionData, matchingLanguages })
             callback()
           } catch (error) {
             io.to(user1socket).emit('ErrorMatching', { errorMessage: 'Please Rejoin Queue' })

--- a/microservices/matchingService/service/matching.js
+++ b/microservices/matchingService/service/matching.js
@@ -62,30 +62,34 @@ class MatchingService {
     return matchingLanguages
   }
 
+  hasMatchingLanguages (user1Languages, user2Languages) {
+    if (user1Languages.length === 0 && user2Languages.length === 0) {
+      return true
+    }
+    const matchingLanguages = this.findMatchingLanguages(user1Languages, user2Languages)
+    if (matchingLanguages.length > 0) {
+      return true
+    }
+  }
+
   isEmpty (difficulty, languages) {
     if (difficulty === 'Easy') {
       for (const user of this.EasyQueue) {
-        const prefLanguages = user.languages
-        const matchingLanguages = this.findMatchingLanguages(prefLanguages, languages)
-        if (matchingLanguages.length > 0) {
+        if (this.hasMatchingLanguages(languages, user.languages)) {
           return false
         }
       }
       return true
     } else if (difficulty === 'Normal') {
       for (const user of this.MediumQueue) {
-        const prefLanguages = user.languages
-        const matchingLanguages = this.findMatchingLanguages(prefLanguages, languages)
-        if (matchingLanguages.length > 0) {
+        if (this.hasMatchingLanguages(languages, user.languages)) {
           return false
         }
       }
       return true
     } else {
       for (const user of this.HardQueue) {
-        const prefLanguages = user.languages
-        const matchingLanguages = this.findMatchingLanguages(prefLanguages, languages)
-        if (matchingLanguages.length > 0) {
+        if (this.hasMatchingLanguages(languages, user.languages)) {
           return false
         }
       }
@@ -105,19 +109,19 @@ class MatchingService {
     }
   }
 
+  isMatchFound (user1Languages, user2Languages) {
+    if (user1Languages.length === 0 && user2Languages.length === 0) {
+      return true
+    }
+    const matchingLanguages = this.findMatchingLanguages(user1Languages, user2Languages)
+    return matchingLanguages.length > 0
+  }
+
   popQueue (difficulty, languages) {
-    let foundMatching = false
     if (difficulty === 'Easy') {
       for (let i = 0; i < this.EasyQueue.length; i++) {
         const user = this.EasyQueue[i]
-        const prefLanguages = user.languages
-        for (const language of languages) {
-          if (prefLanguages.includes(language)) {
-            foundMatching = true
-            break
-          }
-        }
-        if (foundMatching) {
+        if (this.isMatchFound(languages, user.languages)) {
           const matchedUser = this.EasyQueue.splice(i, 1)[0]
           return matchedUser
         }
@@ -126,15 +130,7 @@ class MatchingService {
     } else if (difficulty === 'Normal') {
       for (let i = 0; i < this.MediumQueue.length; i++) {
         const user = this.MediumQueue[i]
-        const prefLanguages = user.languages
-
-        for (const language of languages) {
-          if (prefLanguages.includes(language)) {
-            foundMatching = true
-            break
-          }
-        }
-        if (foundMatching) {
+        if (this.isMatchFound(languages, user.languages)) {
           const matchedUser = this.MediumQueue.splice(i, 1)[0]
           return matchedUser
         }
@@ -143,15 +139,7 @@ class MatchingService {
     } else if (difficulty === 'Hard') {
       for (let i = 0; i < this.HardQueue.length; i++) {
         const user = this.HardQueue[i]
-        const prefLanguages = user.languages
-
-        for (const language of languages) {
-          if (prefLanguages.includes(language)) {
-            foundMatching = true
-            break
-          }
-        }
-        if (foundMatching) {
+        if (this.isMatchFound(languages, user.languages)) {
           const matchedUser = this.HardQueue.splice(i, 1)[0]
           return matchedUser
         }

--- a/microservices/websocketServer/app.js
+++ b/microservices/websocketServer/app.js
@@ -92,6 +92,39 @@ io.on('connection', (socket) => {
     }
   })
 
+  socket.on('ChangeEditorLanguage', ({ language }, callback) => {
+    try {
+      console.log(socket.id)
+      console.log(language)
+      const roomId = socketToRoom[socket.id]
+      for (const index in roomIdToSocketId[roomId]) {
+        const socket2id = roomIdToSocketId[roomId][index]
+        if (socket2id !== socket.id) {
+          io.to(socket2id).emit('CheckChangeEditorLanguage', { language })
+        }
+      }
+      callback()
+    } catch (error) {
+      return callback(error)
+    }
+  })
+
+  socket.on('ConfirmChangeEditorLanguage', ({ agree, language }, callback ) => {
+    try {
+      console.log(socket.id)
+      const roomId = socketToRoom[socket.id]
+      for (const index in roomIdToSocketId[roomId]) {
+        const socket2id = roomIdToSocketId[roomId][index]
+        if (socket2id !== socket.id) {
+          io.to(socket2id).emit('ConfirmChangeEditorLanguage', { agree, language })
+        }
+      }
+      callback()
+    } catch (error) {
+      return callback(error)
+    }
+  })
+
   socket.on('disconnect', async () => {
     console.log('disconnecting other peer')
     const roomId = socketToRoom[socket.id]

--- a/microservices/websocketServer/app.js
+++ b/microservices/websocketServer/app.js
@@ -109,7 +109,7 @@ io.on('connection', (socket) => {
     }
   })
 
-  socket.on('ConfirmChangeEditorLanguage', ({ agree, language }, callback ) => {
+  socket.on('ConfirmChangeEditorLanguage', ({ agree, language }, callback) => {
     try {
       console.log(socket.id)
       const roomId = socketToRoom[socket.id]


### PR DESCRIPTION
# Description

Displays matching programming languages between 2 users in collab page (Will be left up to front end whether he wants code editor to only allow for matching programming languages to be displayed etc.)

Allow for programming language used in editor to be synced for both matched users
Flow of change in programming language:
  1. User 1 changes language
  2. Alert pops up for user 1 that prevents user 1 from editing code further
  3. User 2 receives an alert pop up that checks whether he wants to change the programming language
  4. Choice propagated to user 1 
Even if you refresh page during this process this pop up still persists, feel free to try to break this and let me know if there are any bugs

Fix code editor code not syncing across users in master branch

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
