### PR TITLE
Implement API to support retrieval of user room history 

### DIFF
--- a/microservices/collabService/src/controller/roomController.js
+++ b/microservices/collabService/src/controller/roomController.js
@@ -84,7 +84,8 @@ const saveHistory = async (req, res) => {
     console.log(questionData)
     console.log(code)
 
-    await historyCollection.doc(rid).set({ user1id, user2id, questionData, code, language, messages })
+    const timestamp = Date.now()
+    await historyCollection.doc(rid).set({ user1id, user2id, questionData, code, language, messages, timestamp })
 
     // Fetch the existing roomId data for user1id
     const user1Doc = await userToRoomCollection.doc(user1id).get()
@@ -106,6 +107,7 @@ const saveHistory = async (req, res) => {
 
     res.status(200).json({ message: 'Successfully save room history' })
   } catch (error) {
+    console.log(error.message)
     res.status(400).json({ error: error.message })
   }
 }

--- a/microservices/collabService/src/controller/roomController.js
+++ b/microservices/collabService/src/controller/roomController.js
@@ -123,6 +123,20 @@ const updateHistory = async (req, res) => {
   }
 }
 
+const getHistory = async (req, res) => {
+  try {
+    const { rid } = req.params
+    console.log('Get history for', rid)
+    const doc = await historyCollection.doc(rid).get()
+    if (!doc.exists) {
+      throw new Error(`Room does not exist: ${rid}`)
+    }
+    res.status(200).json({ roomInfo: doc.data() })
+  } catch (error) {
+    res.status(400).json({ error: error.message })
+  }
+}
+
 const changeQuestion = async (req, res) => {
   try {
     const { rid, questionData } = req.body
@@ -150,6 +164,7 @@ module.exports = {
   checkRoom,
   saveHistory,
   updateHistory,
+  getHistory,
   changeQuestion,
   leaveRoom
 }

--- a/microservices/collabService/src/routes/roomRoutes.js
+++ b/microservices/collabService/src/routes/roomRoutes.js
@@ -6,6 +6,7 @@ router.post('/room/createroom', roomController.createRoom)
 router.post('/room/checkroom', roomController.checkRoom)
 router.post('/room/savehistory', roomController.saveHistory)
 router.post('/room/updatehistory', roomController.updateHistory)
+router.get('/room/getHistory/:rid', roomController.getHistory)
 router.post('/room/changequestion', roomController.changeQuestion)
 router.post('/room/leaveroom', roomController.leaveRoom)
 

--- a/microservices/collabService/src/tests/unit.spec.js
+++ b/microservices/collabService/src/tests/unit.spec.js
@@ -64,7 +64,20 @@ collectionStub.withArgs('history').returns({
   doc: sandbox.stub().callsFake((rid) => {
     return {
       set: sandbox.stub().resolves({ message: 'Done!' }),
-      update: sandbox.stub().resolves({ message: 'Done!' })
+      update: sandbox.stub().resolves({ message: 'Done!' }),
+      get: sandbox.stub().resolves({
+        data: () => ({
+          code: 'Please choose a language to begin!\n',
+          questionData: {
+            question: fakeQuestionData
+          },
+          user2id: 'user2',
+          messages: [],
+          language: '',
+          user1id: 'user1'
+        }),
+        exists: true
+      })
     }
   })
 })
@@ -79,7 +92,7 @@ collectionStub.withArgs('useridToRoom').returns({
 })
 
 // Import functions to test
-const { createRoom, checkRoom, saveHistory, updateHistory, changeQuestion, leaveRoom } = require('../controller/roomController')
+const { createRoom, checkRoom, saveHistory, updateHistory, changeQuestion, leaveRoom, getHistory } = require('../controller/roomController')
 
 describe('Unit Test for /collab', () => {
   before('before', () => {
@@ -181,6 +194,33 @@ describe('Unit Test for /collab', () => {
         }
       }
       await updateHistory(req, res)
+    })
+  })
+
+  describe('Get history on /getHistory', () => {
+    it('should update room history', async () => {
+      const req = {
+        params: {
+          rid: 'room_id' // Provide a valid room ID
+        }
+      }
+      const res = {
+        status: (code) => {
+          expect(code).to.equal(200)
+          return {
+            json: (data) => {
+              expect(data).to.have.property('roomInfo')
+              expect(data.roomInfo).to.have.property('questionData')
+              expect(data.roomInfo).to.have.property('code')
+              expect(data.roomInfo).to.have.property('language')
+              expect(data.roomInfo).to.have.property('messages')
+              expect(data.roomInfo).to.have.property('user1id')
+              expect(data.roomInfo).to.have.property('user2id')
+            }
+          }
+        }
+      }
+      await getHistory(req, res)
     })
   })
 

--- a/microservices/userService/src/controller/user.controller.js
+++ b/microservices/userService/src/controller/user.controller.js
@@ -123,6 +123,7 @@ exports.deregisterUser = async function (uid) {
   try {
     await admin.auth().deleteUser(uid)
     await userCollection.doc(uid).delete()
+    await userHistoryCollection.doc(uid).delete()
     return 'OK'
   } catch (error) {
     return Promise.reject(error)

--- a/microservices/userService/src/controller/user.controller.js
+++ b/microservices/userService/src/controller/user.controller.js
@@ -3,6 +3,7 @@ const admin = require('firebase-admin')
 
 const db = admin.firestore()
 const userCollection = db.collection('users')
+const userHistoryCollection = db.collection('useridToRoom')
 
 const supportedLanguages = require('../utils/supportedLanguages')
 
@@ -100,6 +101,19 @@ exports.getUserInfo = async function (uid) {
         return userRecord.toJSON()
       })
     return userData
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+
+exports.getUserHistory = async function (uid) {
+  try {
+    const docRef = userHistoryCollection.doc(uid)
+    const doc = await docRef.get()
+    if (!doc.exists) {
+      return []
+    }
+    return doc.data().roomId
   } catch (error) {
     return Promise.reject(error)
   }

--- a/microservices/userService/src/routes/user.route.js
+++ b/microservices/userService/src/routes/user.route.js
@@ -85,6 +85,17 @@ router.get('/:uid', async (req, res) => {
   }
 })
 
+router.get('/history/:uid', async (req, res) => {
+  console.log('Get User Info')
+  try {
+    const { uid } = req.params
+    const userHistory = await userController.getUserHistory(uid)
+    res.status(200).json({ history: userHistory })
+  } catch (error) {
+    res.status(400).json({ error: error.message })
+  }
+})
+
 router.delete('/deregister/:uid', tokenManager.authenticateJWT, async (req, res) => {
   console.log('Deregister User')
   try {

--- a/microservices/userService/src/tests/userIntegration.spec.js
+++ b/microservices/userService/src/tests/userIntegration.spec.js
@@ -15,6 +15,7 @@ const testUser = {
 }
 const defaultLanguage = ['Python']
 const newLanguages = ['Java', 'C++']
+const history = ['abcd-efgh-xyz0']
 
 describe('Integration Test with firebase for /user', () => {
   before('before', () => {
@@ -71,6 +72,15 @@ describe('Integration Test with firebase for /user', () => {
       await userController.updateLanguage({ uid, languages: newLanguages })
       const languageData = await userController.getLanguage(uid)
       expect(languageData).to.deep.equal(newLanguages)
+    })
+  })
+
+  describe('Get room history on /history', () => {
+    it('User history should be retrieved correctly without error', async () => {
+      const { uid } = testUser
+      await admin.firestore().collection('useridToRoom').doc(uid).set({ roomId: history })
+      const roomHistory = await userController.getUserHistory(uid)
+      expect(roomHistory).to.deep.equal(history)
     })
   })
 


### PR DESCRIPTION
# Description

2 APIs are added:

`/user/history/:uid` to retrieve a list of rooms (rids) a user has participated in
`/collab/getHistory/:rid` to retrieve the room details

Furthermore, `/user/deregister/:uid` is updated to remove a user's history

Fixes #75, #77

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
