### PR TITLE
APIs for generating JWT tokens with roles and authorization 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
           FIREBASE_ADMIN_CLIENT_ID: ${{ secrets.FIREBASE_ADMIN_CLIENT_ID }}
           FIREBASE_ADMIN_AUTH_PROVIDER_X509_CERT_URL: ${{ secrets.FIREBASE_ADMIN_AUTH_PROVIDER_X509_CERT_URL }}
           FIREBASE_ADMIN_CLIENT_X509_CERT_URL: ${{ secrets.FIREBASE_ADMIN_CLIENT_X509_CERT_URL }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PW: ${{ secrets.ADMIN_PW }}
         run: npm run test-user
 
       - name: Run Tests on Room Service

--- a/frontend/src/pages/LoginPage.js
+++ b/frontend/src/pages/LoginPage.js
@@ -23,6 +23,7 @@ import {
 import { useNavigate } from 'react-router-dom'
 // import { setErrorMessage, setShowError } from '../redux/ErrorSlice.js'
 import LoginPageBanner from '../components/FrontPageBanner.js'
+import axios from 'axios'
 
 function LoginPage () {
   initFirebase()
@@ -54,7 +55,11 @@ function LoginPage () {
       dispatch(setStateEmail(useremail))
       console.log(userCredentials)
       const idToken = await userCredentials.user.getIdToken()
-      dispatch(setIdToken(idToken))
+      const tokenResult = await axios.post('http://localhost:3001/user/token', {
+        uid: userid,
+        idToken
+      })
+      dispatch(setIdToken(tokenResult.data.token))
       console.log('Login successful')
       dispatch(setLoginStatus(true))
       navigate('/home')

--- a/frontend/src/pages/SignupPage.js
+++ b/frontend/src/pages/SignupPage.js
@@ -86,7 +86,11 @@ function SignupPage () {
       const useremail = userCredentials.user.email
       dispatch(setStateEmail(useremail))
       const idToken = await userCredentials.user.getIdToken()
-      dispatch(setIdToken(idToken))
+      const tokenResult = await axios.post('http://localhost:3001/user/token', {
+        uid: userid,
+        idToken
+      })
+      dispatch(setIdToken(tokenResult.data.token))
       console.log('Signup successful')
       console.log('idToken', idToken)
       dispatch(setLoginStatus(true))

--- a/microservices/userService/src/routes/user.route.js
+++ b/microservices/userService/src/routes/user.route.js
@@ -96,7 +96,7 @@ router.get('/history/:uid', async (req, res) => {
   }
 })
 
-router.delete('/deregister/:uid', tokenManager.authenticateJWT, async (req, res) => {
+router.delete('/deregister/:uid', tokenManager.authenticateValidUser, async (req, res) => {
   console.log('Deregister User')
   try {
     const { uid } = req.params
@@ -104,6 +104,30 @@ router.delete('/deregister/:uid', tokenManager.authenticateJWT, async (req, res)
     res.status(200).json({ message: 'User deregistered successfully' })
   } catch (error) {
     res.status(400).json({ error: error.message })
+  }
+})
+
+router.post('/token', async (req, res) => {
+  console.log('Generate Token for User')
+  try {
+    const { uid, idToken } = req.body
+    const jwtToken = await userController.generateJwt(
+      uid,
+      (role) => tokenManager.generateToken(idToken, role)
+    )
+    res.status(200).json({ token: jwtToken })
+  } catch (error) {
+    res.status(400).json({ error: error.message })
+  }
+})
+
+router.get('/authorizeAdmin/:uid', async (req, res) => {
+  console.log('Authorization for admins')
+  try {
+    await tokenManager.authorizeAdmin(req, res, () => {})
+    res.status(200).json({ message: 'Authorized' })
+  } catch (error) {
+    return res
   }
 })
 

--- a/microservices/userService/src/tests/unit.spec.js
+++ b/microservices/userService/src/tests/unit.spec.js
@@ -8,6 +8,9 @@ const userController = require('../controller/user.controller')
 const admins = require('firebase-admin')
 const adminAuth = admins.auth()
 const firestore = admins.firestore()
+const TokenManager = require('../utils/tokenManager')
+const tokenManager = new TokenManager(admins)
+const jwt = require('jsonwebtoken')
 
 // Test user
 const testUser = {
@@ -18,6 +21,7 @@ const testUser = {
   displayName: 'John Doe',
   newDisplayName: 'John Smith'
 }
+const idToken = 'eyasdsadas'
 const defaultLanguage = ['Python']
 const newLanguages = ['Java', 'C++']
 
@@ -125,6 +129,22 @@ describe('Unit Test for /user', () => {
       await userController.updateLanguage({ uid, languages: newLanguages })
       const languageData = await userController.getLanguage(uid)
       expect(languageData).to.deep.equal(newLanguages)
+    })
+  })
+
+  describe('Generate token on /generateJwt', () => {
+    it('User token should be generated correctly', async () => {
+      const { uid } = testUser
+      const jwtToken = await userController.generateJwt(uid, (role) => tokenManager.generateToken(idToken, role))
+      const decoded = jwt.verify(jwtToken, tokenManager.secretKey)
+      expect(decoded.role).to.equal('user')
+    })
+
+    it('Admin token should be generated correctly', async () => {
+      const uid = 'admin'
+      const jwtToken = await userController.generateJwt(uid, (role) => tokenManager.generateToken(idToken, role))
+      const decoded = jwt.verify(jwtToken, tokenManager.secretKey)
+      expect(decoded.role).to.equal('admin')
     })
   })
 

--- a/microservices/userService/src/utils/supportedLanguages.js
+++ b/microservices/userService/src/utils/supportedLanguages.js
@@ -1,3 +1,3 @@
-const supportedLanguages = ['Python', 'Java', 'C', 'C++', 'C#', 'JavaScript']
+const SupportedLanguages = ['Python', 'Java', 'C', 'C++', 'C#', 'JavaScript']
 
-module.exports = supportedLanguages
+module.exports = SupportedLanguages

--- a/microservices/userService/src/utils/tokenManager.js
+++ b/microservices/userService/src/utils/tokenManager.js
@@ -1,28 +1,89 @@
+const path = require('path')
+const envPath = path.join(__dirname, '../../configs/.env')
+require('dotenv').config({ path: envPath })
+
+const jwt = require('jsonwebtoken')
+const UserRoles = require('../utils/userRoles')
+
 class TokenManager {
   constructor (firebaseAdmin) {
     this.admin = firebaseAdmin
+    this.secretKey = process.env.JWT_SECRET
   }
 
-  authenticateJWT = async (req, res, next) => {
+  generateToken = (idToken, role) => {
+    const payload = {
+      idToken,
+      role
+    }
+    const token = jwt.sign(payload, this.secretKey, { expiresIn: '3h' })
+    return token
+  }
+
+  checkValidIdToken = async (uid, idToken, next) => {
+    this.admin
+      .auth()
+      .verifyIdToken(idToken)
+      .then(function (decodedToken) {
+        if (uid !== decodedToken.user_id) {
+          throw new Error('Invalid token for current user')
+        }
+        return next()
+      })
+  }
+
+  checkExpired = async (decodedToken) => {
+    if (decodedToken.exp && Date.now() / 1000 > decodedToken.exp) {
+      return true
+    }
+    return false
+  }
+
+  authenticateValidUser = async (req, res, next) => {
     const authHeader = req.headers.authorization
 
     if (authHeader) {
-      const idToken = authHeader.split(' ')[1]
-      this.admin
-        .auth()
-        .verifyIdToken(idToken)
-        .then(function (decodedToken) {
-          if (req.params.uid !== decodedToken.user_id) {
-            throw new Error('Invalid token for current user')
-          }
-          return next()
-        })
-        .catch(function (error) {
-          console.log(error)
-          return res.sendStatus(403)
-        })
+      const jwtToken = authHeader.split(' ')[1]
+      const decoded = jwt.verify(jwtToken, this.secretKey)
+
+      if (this.checkExpired(decoded) === true) {
+        return res.status(401).json({ error: 'Token has expired' })
+      }
+
+      try {
+        this.checkValidIdToken(req.params.uid, decoded.idToken, next)
+      } catch (error) {
+        console.log(error)
+        return res.status(403).json({ error: 'Forbidden' })
+      }
     } else {
-      res.sendStatus(401)
+      return res.status(401).json({ error: 'Unauthorized' })
+    }
+  }
+
+  authorizeAdmin = async (req, res, next) => {
+    const authHeader = req.headers.authorization
+
+    if (authHeader) {
+      const jwtToken = authHeader.split(' ')[1]
+      const decoded = jwt.verify(jwtToken, this.secretKey)
+
+      if (this.checkExpired(decoded) === true) {
+        return res.status(401).json({ error: 'Token has expired' })
+      }
+
+      if (decoded.role !== UserRoles.admin) {
+        return res.status(401).json({ error: 'Unauthorized' })
+      }
+
+      try {
+        this.checkValidIdToken(req.params.uid, decoded.idToken, next)
+      } catch (error) {
+        console.log(error)
+        return res.status(403).json({ error: 'Forbidden' })
+      }
+    } else {
+      return res.status(401).json({ error: 'Unauthorized' })
     }
   }
 }

--- a/microservices/userService/src/utils/userRoles.js
+++ b/microservices/userService/src/utils/userRoles.js
@@ -1,0 +1,6 @@
+const UserRoles = {
+  admin: 'admin',
+  user: 'user'
+}
+
+module.exports = UserRoles


### PR DESCRIPTION
# Description

To support admin authorization for admin pages

POST to `/token` with body `{ uid, idToken }` to generate JWT token with the user's role
GET to `/authorizeAdmin/:uid` to check if user is authorized as admin

Added new tests for the new functionalities

Fixes #72 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
